### PR TITLE
Made merlinDiagnostics default to true + fixed documentation (config.md)

### DIFF
--- a/ocaml-lsp-server/docs/ocamllsp/config.md
+++ b/ocaml-lsp-server/docs/ocamllsp/config.md
@@ -23,11 +23,11 @@ interface config {
   codelens: { enable : boolean }
 
   /**
-  * Enable/Disable Dune diagnostics
+  * Enable/Disable Merlin (Dune) diagnostics
   * @default true
   * @since 1.18
   */
-  duneDiagnostics: { enable : boolean }
+  merlinDiagnostics: { enable : boolean }
 
   /**
   * Enable/Disable Inlay Hints

--- a/ocaml-lsp-server/src/config_data.ml
+++ b/ocaml-lsp-server/src/config_data.ml
@@ -26,7 +26,7 @@ module SyntaxDocumentation = struct
 end
 
 module MerlinDiagnostics = struct
-  type t = { enable : bool [@default false] }
+  type t = { enable : bool [@default true] }
   [@@deriving yojson] [@@yojson.allow_extra_fields]
 end
 
@@ -68,7 +68,7 @@ let default =
         ; hint_let_syntax_ppx = false
         }
   ; syntax_documentation = Some { enable = false }
-  ; merlin_diagnostics = Some { enable = false }
+  ; merlin_diagnostics = Some { enable = true }
   ; shorten_merlin_diagnostics = Some { enable = false }
   ; ppx_css_colors = Some { enable = true }
   }

--- a/ocaml-lsp-server/src/configuration.ml
+++ b/ocaml-lsp-server/src/configuration.ml
@@ -65,8 +65,8 @@ let update t { DidChangeConfigurationParams.settings } =
 
 let display_merlin_diagnostics t =
   match t.data.merlin_diagnostics with
-  | Some { enable = true } -> true
-  | Some { enable = false } | None -> false
+  | Some { enable = true } | None -> true
+  | Some { enable = false } -> false
 ;;
 
 let shorten_merlin_diagnostics t =


### PR DESCRIPTION
This change just makes the merlinDiagnostics setting of the ls true by default and fixes its documentation. 

This was prompted by annoyances setting this up with neovim since the docs were wrong and it wasn't enabled by default unlike ocaml/ocaml-lsp (also because the internal branch isn't master yet).