### PR TITLE
re-export String.is_prefix and is_suffix from Base

### DIFF
--- a/ocaml-lsp-server/src/import.ml
+++ b/ocaml-lsp-server/src/import.ml
@@ -78,6 +78,8 @@ module String = struct
     let substr_index_exn = substr_index_exn
     let substr_index = substr_index
     let prefix = prefix
+    let is_prefix = is_prefix
+    let is_suffix = is_suffix
     let lfindi = lfindi
     let filter = filter
   end


### PR DESCRIPTION
ocaml-lsp is broken in the tip of oxcaml/opam-repository because of some missing imports in ocaml-lsp.

This PR fixes that.

I picked the "internal" branch as the base to merge into, but I wonder whether it makes more sense to have a main branch as the version deployed to opam-repository as the "official" open source version to be used by the opam-repository, and merge it into that?